### PR TITLE
Compile fix for OSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,8 @@ add_library(oculus_rviz_plugins
 )
 
 target_link_libraries(oculus_rviz_plugins
+  ${catkin_LIBRARIES}
+  ${QT_LIBRARIES}
   ${OculusSDK_LIBRARIES}
   ${BOOST_LIBRARIES}
 )

--- a/src/fixed_view_controller.cpp
+++ b/src/fixed_view_controller.cpp
@@ -77,7 +77,6 @@ FixedViewController::~FixedViewController()
 
 void FixedViewController::reset()
 {
-//   FramePositionTrackingViewController::reset();
 }
 
 void FixedViewController::update(float dt, float ros_dt)

--- a/src/fixed_view_controller.cpp
+++ b/src/fixed_view_controller.cpp
@@ -77,7 +77,7 @@ FixedViewController::~FixedViewController()
 
 void FixedViewController::reset()
 {
-  FramePositionTrackingViewController::reset();
+//   FramePositionTrackingViewController::reset();
 }
 
 void FixedViewController::update(float dt, float ros_dt)


### PR DESCRIPTION
Compile fix for OSX. I'm not sure where `FramePositionTrackingViewController::reset();` was coming from, I didn't see it defined anywhere..

ps. I don't have it working yet, but this is most likely due to a rviz bug (https://github.com/ros-visualization/rviz/issues/646)
